### PR TITLE
AIRAVATA-3685 Add GitHub Action to test custom Django app installability

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
   "app_config_class_name": "{{ cookiecutter.project_name | slugify(separator=' ') | title | replace(' ', '') }}Config",
   "version": "0.1.0",
   "_copy_without_render": [
-      "*.html"
+      "*.html",
+      ".github/workflows/*.yml"
   ]
 }

--- a/{{cookiecutter.project_slug}}/.github/workflows/install-test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/install-test.yml
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Test Django App Install
+
+on: [push, pull_request]
+
+jobs:
+  install-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout custom Django app
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Clone Airavata Django Portal
+        run: git clone --depth 1 https://github.com/apache/airavata-django-portal.git
+
+      - name: Install portal dependencies
+        run: |
+          cd airavata-django-portal
+          pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+
+      - name: Install custom Django app
+        run: |
+          cd airavata-django-portal
+          pip install ..
+
+      - name: Run migrations
+        run: |
+          cd airavata-django-portal
+          cp django_airavata/settings_local.py.sample django_airavata/settings_local.py
+          python manage.py migrate
+
+      - name: Django system check
+        run: |
+          cd airavata-django-portal
+          python manage.py check


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow template (`install-test.yml`) to the cookiecutter template so that every generated custom Django app ships with CI that validates it can install cleanly into the Airavata Django Portal.

The workflow:
1. Checks out the custom Django app
2. Clones the Airavata Django Portal
3. Installs portal dependencies via `requirements.txt`
4. Installs the custom Django app into the portal (`pip install ..`)
5. Runs `python manage.py migrate` to validate database migrations
6. Runs `python manage.py check` to run Django system checks

This catches common issues early:
- Missing dependencies in `setup.cfg`
- Broken database migrations
- Incorrect `setup.py` / `setup.cfg` configuration
- Portal integration problems

Also adds `.github/workflows/*.yml` to `_copy_without_render` in `cookiecutter.json` to prevent Jinja2 from interpreting GitHub Actions `${{ }}` expression syntax as cookiecutter template variables.

**JIRA:** [AIRAVATA-3685](https://issues.apache.org/jira/browse/AIRAVATA-3685)

## Design decisions

- **Python 3.10**: Matches the highest version in the portal's own CI matrix
- **`requirements.txt` over `requirements-dev.txt`**: Only migrate and check are needed, not dev tooling (flake8, test runners)
- **`--depth 1` clone**: Faster CI runs, full git history is unnecessary
- **No JS build step**: Per the JIRA issue description, JS compilation is not needed for install validation
- **Apache License header**: Consistent with the portal's existing workflow file

## Test plan

- [ ] Run `cookiecutter` with this template and verify the generated project includes `.github/workflows/install-test.yml`
- [ ] Push the generated project to GitHub and confirm the workflow runs successfully
- [ ] Verify `_copy_without_render` prevents Jinja2 from modifying the YAML file